### PR TITLE
Release kubectl-access binaries using goreleaser

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -1,0 +1,43 @@
+name: release-binary
+
+on:
+  schedule:
+    - cron: '43 11 * * *'
+  push:
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+
+      - name: Build GoReleaser snapshot
+        uses: goreleaser/goreleaser-action@v4
+        if: github.event_name == 'pull_request'
+        with:
+          version: latest
+          args: release --clean --snapshot
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        if: github.event_name != 'pull_request'
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /webhook-auditer
 /webhook-validator
 /.go
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,41 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - main: ./cmd/kubectl-access
+    id: kubectl-access
+    binary: kubectl-access
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+    - goos: windows
+      format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+release:
+  draft: true
+
+# The lines beneath this are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj


### PR DESCRIPTION
Uses https://goreleaser.com, initial inspiration gleaned from https://github.com/alecjacobs5401/kubectl-sick-pods.