### PR TITLE
Fix goreleaser issues

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -28,14 +28,14 @@ jobs:
 
       - name: Build GoReleaser snapshot
         uses: goreleaser/goreleaser-action@v4
-        if: github.event_name == 'pull_request'
+        if: contains(fromJSON('["pull_request", "schedule"]'), github.event_name) # only check if release is possible
         with:
           version: latest
           args: release --clean --snapshot
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' # tag was pushed
         with:
           version: latest
           args: release --clean

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,7 @@ archives:
   - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of uname.
     name_template: >-
-      {{ .ProjectName }}_
+      kubectl-access_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386


### PR DESCRIPTION
- fix filenames of archives for `kubectl-access`
- do not attempt to release on scheduled runs, just do a "snapshot" test build