### PR TITLE
Display a human-friendly summary of the request in `request grant`

### DIFF
--- a/cmd/kubectl-access/kubectl-access.go
+++ b/cmd/kubectl-access/kubectl-access.go
@@ -323,6 +323,28 @@ func (ac *accessCommand) Grant(cmd *cobra.Command, requestName string) error {
 		return fmt.Errorf("could not print object: %w", err)
 	}
 
+	duration := "once"
+	if accessRequest.Spec.ValidFor != "" {
+		duration = fmt.Sprintf("for %s", accessRequest.Spec.ValidFor)
+	}
+	command := fmt.Sprintf("%q", accessRequest.Spec.ExecOptions.Command)
+	if len(accessRequest.Spec.ExecOptions.Command) == 0 {
+		command = "ANY command"
+	}
+	fmt.Println("---")
+	fmt.Printf(`%q requested by %q
+
+- requesting access to %q and container %q in namespace %q
+- to run %s
+- %s
+`,
+		accessRequest.Name, accessRequest.Spec.UserInfo.Username,
+		accessRequest.Spec.ForObject.Name, accessRequest.Spec.ExecOptions.Container, accessRequest.Spec.ForObject.Namespace,
+		command,
+		duration,
+	)
+	fmt.Println()
+
 	fmt.Print("Grant access to the request above ([yN])? ")
 	scanner := bufio.NewScanner(os.Stdin)
 	if !scanner.Scan() {

--- a/cmd/kubectl-access/kubectl-access.go
+++ b/cmd/kubectl-access/kubectl-access.go
@@ -315,6 +315,9 @@ func (ac *accessCommand) Grant(cmd *cobra.Command, requestName string) error {
 		return fmt.Errorf("could not get accessrequest: %w", err)
 	}
 
+	// remove this field which contains no useful information for this and makes the output much longer than it needs to be
+	accessRequest.ManagedFields = nil
+
 	// TODO: get this set automatically by the client
 	accessRequest.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Group: "spreadgroup.com", Kind: "AccessRequest"})
 	printer := &printers.YAMLPrinter{}

--- a/cmd/kubectl-access/kubectl-access.go
+++ b/cmd/kubectl-access/kubectl-access.go
@@ -223,8 +223,11 @@ func (ac *accessCommand) Request(cmd *cobra.Command, args []string) error {
 	}
 
 	currentContext := rawConfig.CurrentContext
-	if ac.genericOptions.Context != nil {
+	if ac.genericOptions.Context != nil && *ac.genericOptions.Context != "" {
 		currentContext = *ac.genericOptions.Context
+	}
+	if currentContext == "" {
+		return fmt.Errorf("no context set")
 	}
 	userName := rawConfig.Contexts[currentContext].AuthInfo
 


### PR DESCRIPTION
This should highlight the important info and make it easier to spot questionable requests.

In addition this silences the `managedFields` field for the `grant` output which improves readability of access requests as well.

Example output:

    $ kubectl access --context dev request exec --valid-for=10m nginx-7fb96c846b-pcnxl
    created accessrequest access-exec-dev-g2vx5 (please wait for an admin to grant the permission)

    $ kubectl access --context k3d-k3s-default grant access-exec-dev-g2vx5
    apiVersion: spreadgroup.com/v1
    kind: AccessRequest
    metadata:
      creationTimestamp: "2023-04-20T12:33:07Z"
      generateName: access-exec-dev-
      generation: 1
      labels:
        username: dev
      name: access-exec-dev-g2vx5
      namespace: default
      resourceVersion: "125569"
      uid: 453279ce-e69f-4a68-9aaf-472e191c440b
    spec:
      customKeys: null
      execOptions:
        apiVersion: v1
        command: []
        container: nginx
        kind: PodExecOptions
        stderr: true
        stdout: true
      forObject:
        name: nginx-7fb96c846b-pcnxl
        namespace: default
        resource:
          group: ""
          resource: pods
          version: v1
        subResource: exec
      userInfo:
        username: dev
      validFor: 10m0s
    ---
    access-exec-dev-g2vx5 requested by "dev"
    
    - requesting access to "nginx-7fb96c846b-pcnxl" and container "nginx" in namespace default
    - to run ANY command
    - for 10m0s

    Grant access to the request above ([yN])?