### PR TITLE
Select the default container if one exists

### DIFF
--- a/cmd/kubectl-request/kubectl-request.go
+++ b/cmd/kubectl-request/kubectl-request.go
@@ -202,12 +202,17 @@ func (ac *accessCommand) Request(cmd *cobra.Command, args []string) error {
 
 	}
 
-	// default to first container if none is set (like `kubectl exec`)
+	// default to default or first container if none is set (like `kubectl exec`)
 	if ac.execOptions.Container == "" {
 		if len(selectedPod.Spec.Containers) == 0 {
 			return fmt.Errorf("no containers in pod %q", selectedPod.Name)
 		}
-		ac.execOptions.Container = selectedPod.Spec.Containers[0].Name
+
+		if selectedPod.ObjectMeta.Annotations["kubectl.kubernetes.io/default-container"] != "" {
+			ac.execOptions.Container = selectedPod.ObjectMeta.Annotations["kubectl.kubernetes.io/default-container"]
+		} else {
+			ac.execOptions.Container = selectedPod.Spec.Containers[0].Name
+		}
 	}
 
 	accessRequestsClient, err := accessrequestsclientv1.NewForConfig(config)

--- a/dev/nginx-deployment.yaml
+++ b/dev/nginx-deployment.yaml
@@ -11,10 +11,19 @@ spec:
       app: nginx
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: nginx
       labels:
         app: nginx
     spec:
       containers:
+      # sleeps forever, used to test that default-container annotations is respected
+      - name: sleeper
+        image: busybox
+        command:
+        - /bin/sh
+        - -c
+        - 'sleep infinity'
       - name: nginx
         image: nginx:1.14.2
         ports:


### PR DESCRIPTION
This was already documented as working in the `--container` flag docs, but now it actually works.

Tested using local test environment with the adjusted `nginx` container:

    $ kubectl request --context jane exec nginx-9d5944bf8-txp9x -- ls -l /etc
    created accessrequest access-exec-jane-qmqql (please wait for an admin to grant the permission)
    $ kubectl get acr access-exec-jane-qmqql -o yaml
    apiVersion: spreadgroup.com/v1
    kind: AccessRequest
    metadata:
      creationTimestamp: "2023-05-11T14:29:57Z"
      generateName: access-exec-jane-
      generation: 1
      labels:
        username: jane
      name: access-exec-jane-qmqql
      namespace: default
      resourceVersion: "196838"
      uid: 599a6f35-771b-46f5-b3d4-6efa00d6d82e
    spec:
      execOptions:
        apiVersion: v1
        command:
        - ls
        - -l
        - /etc
        container: nginx
        kind: PodExecOptions
        stderr: true
        stdout: true
      forObject:
        name: nginx-9d5944bf8-txp9x
        namespace: default
        resource:
          group: ""
          resource: pods
          version: v1
        subResource: exec
      userInfo:
        username: jane

Without this fix it would have defaulted to the first container, i.e. the `sleeper` container in the case of the nginx example.